### PR TITLE
Updated for 0.2 version

### DIFF
--- a/tensorflow-examples/pom.xml
+++ b/tensorflow-examples/pom.xml
@@ -27,16 +27,6 @@
     </dependency>
   </dependencies>
 
-  <repositories>
-    <repository>
-      <id>tensorflow-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <build>
     <plugins>
       <plugin>

--- a/tensorflow-examples/pom.xml
+++ b/tensorflow-examples/pom.xml
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>org.tensorflow</groupId>
       <artifactId>tensorflow-core-platform</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>0.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.tensorflow</groupId>
       <artifactId>tensorflow-framework</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>0.2.0</version>
     </dependency>
   </dependencies>
 

--- a/tensorflow-examples/src/main/java/org/tensorflow/model/examples/cnn/lenet/CnnMnist.java
+++ b/tensorflow-examples/src/main/java/org/tensorflow/model/examples/cnn/lenet/CnnMnist.java
@@ -40,10 +40,10 @@ import org.tensorflow.op.nn.Relu;
 import org.tensorflow.op.nn.Softmax;
 import org.tensorflow.op.nn.SoftmaxCrossEntropyWithLogits;
 import org.tensorflow.op.random.TruncatedNormal;
-import org.tensorflow.tools.Shape;
-import org.tensorflow.tools.ndarray.ByteNdArray;
-import org.tensorflow.tools.ndarray.FloatNdArray;
-import org.tensorflow.tools.ndarray.index.Indices;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.ndarray.ByteNdArray;
+import org.tensorflow.ndarray.FloatNdArray;
+import org.tensorflow.ndarray.index.Indices;
 import org.tensorflow.framework.optimizers.AdaDelta;
 import org.tensorflow.framework.optimizers.AdaGrad;
 import org.tensorflow.framework.optimizers.AdaGradDA;
@@ -160,9 +160,9 @@ public class CnnMnist {
     // Loss function & regularization
     OneHot<TFloat32> oneHot = tf
         .oneHot(labels, tf.constant(10), tf.constant(1.0f), tf.constant(0.0f));
-    SoftmaxCrossEntropyWithLogits<TFloat32> batchLoss = tf.nn
-        .softmaxCrossEntropyWithLogits(logits, oneHot);
-    Mean<TFloat32> labelLoss = tf.math.mean(batchLoss.loss(), tf.constant(0));
+    Operand<TFloat32> batchLoss = tf.nn
+        .softmaxCrossEntropyWithLogits(logits, oneHot, -1);
+    Mean<TFloat32> labelLoss = tf.math.mean(batchLoss, tf.constant(0));
     Add<TFloat32> regularizers = tf.math.add(tf.nn.l2Loss(fc1Weights), tf.math
         .add(tf.nn.l2Loss(fc1Biases),
             tf.math.add(tf.nn.l2Loss(fc2Weights), tf.nn.l2Loss(fc2Biases))));

--- a/tensorflow-examples/src/main/java/org/tensorflow/model/examples/cnn/lenet/CnnMnist.java
+++ b/tensorflow-examples/src/main/java/org/tensorflow/model/examples/cnn/lenet/CnnMnist.java
@@ -38,7 +38,7 @@ import org.tensorflow.op.nn.Conv2d;
 import org.tensorflow.op.nn.MaxPool;
 import org.tensorflow.op.nn.Relu;
 import org.tensorflow.op.nn.Softmax;
-import org.tensorflow.op.nn.SoftmaxCrossEntropyWithLogits;
+import org.tensorflow.op.nn.raw.SoftmaxCrossEntropyWithLogits;
 import org.tensorflow.op.random.TruncatedNormal;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.ndarray.ByteNdArray;
@@ -160,9 +160,9 @@ public class CnnMnist {
     // Loss function & regularization
     OneHot<TFloat32> oneHot = tf
         .oneHot(labels, tf.constant(10), tf.constant(1.0f), tf.constant(0.0f));
-    Operand<TFloat32> batchLoss = tf.nn
-        .softmaxCrossEntropyWithLogits(logits, oneHot, -1);
-    Mean<TFloat32> labelLoss = tf.math.mean(batchLoss, tf.constant(0));
+    SoftmaxCrossEntropyWithLogits<TFloat32> batchLoss = tf.nn.raw
+            .softmaxCrossEntropyWithLogits(logits, oneHot);
+    Mean<TFloat32> labelLoss = tf.math.mean(batchLoss.loss(), tf.constant(0));
     Add<TFloat32> regularizers = tf.math.add(tf.nn.l2Loss(fc1Weights), tf.math
         .add(tf.nn.l2Loss(fc1Biases),
             tf.math.add(tf.nn.l2Loss(fc2Weights), tf.nn.l2Loss(fc2Biases))));

--- a/tensorflow-examples/src/main/java/org/tensorflow/model/examples/cnn/vgg/VGGModel.java
+++ b/tensorflow-examples/src/main/java/org/tensorflow/model/examples/cnn/vgg/VGGModel.java
@@ -35,7 +35,7 @@ import org.tensorflow.op.math.Mean;
 import org.tensorflow.op.nn.Conv2d;
 import org.tensorflow.op.nn.MaxPool;
 import org.tensorflow.op.nn.Relu;
-import org.tensorflow.op.nn.SoftmaxCrossEntropyWithLogits;
+import org.tensorflow.op.nn.raw.SoftmaxCrossEntropyWithLogits;
 import org.tensorflow.op.random.TruncatedNormal;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.ndarray.ByteNdArray;
@@ -159,9 +159,9 @@ public class VGGModel implements AutoCloseable {
         // Loss function & regularization
         OneHot<TFloat32> oneHot = tf
                 .oneHot(labels, tf.constant(10), tf.constant(1.0f), tf.constant(0.0f));
-        Operand<TFloat32> batchLoss = tf.nn
-                .softmaxCrossEntropyWithLogits(logits, oneHot, -1);
-        Mean<TFloat32> labelLoss = tf.math.mean(batchLoss, tf.constant(0));
+        SoftmaxCrossEntropyWithLogits<TFloat32> batchLoss = tf.nn.raw
+                .softmaxCrossEntropyWithLogits(logits, oneHot);
+        Mean<TFloat32> labelLoss = tf.math.mean(batchLoss.loss(), tf.constant(0));
         Add<TFloat32> regularizers = tf.math.add(tf.nn.l2Loss(fc1Weights), tf.math
                 .add(tf.nn.l2Loss(fc1Biases),
                         tf.math.add(tf.nn.l2Loss(fc2Weights), tf.nn.l2Loss(fc2Biases))));

--- a/tensorflow-examples/src/main/java/org/tensorflow/model/examples/cnn/vgg/VGGModel.java
+++ b/tensorflow-examples/src/main/java/org/tensorflow/model/examples/cnn/vgg/VGGModel.java
@@ -37,10 +37,10 @@ import org.tensorflow.op.nn.MaxPool;
 import org.tensorflow.op.nn.Relu;
 import org.tensorflow.op.nn.SoftmaxCrossEntropyWithLogits;
 import org.tensorflow.op.random.TruncatedNormal;
-import org.tensorflow.tools.Shape;
-import org.tensorflow.tools.ndarray.ByteNdArray;
-import org.tensorflow.tools.ndarray.FloatNdArray;
-import org.tensorflow.tools.ndarray.index.Indices;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.ndarray.ByteNdArray;
+import org.tensorflow.ndarray.FloatNdArray;
+import org.tensorflow.ndarray.index.Indices;
 import org.tensorflow.types.TFloat32;
 import org.tensorflow.types.TUint8;
 
@@ -159,9 +159,9 @@ public class VGGModel implements AutoCloseable {
         // Loss function & regularization
         OneHot<TFloat32> oneHot = tf
                 .oneHot(labels, tf.constant(10), tf.constant(1.0f), tf.constant(0.0f));
-        SoftmaxCrossEntropyWithLogits<TFloat32> batchLoss = tf.nn
-                .softmaxCrossEntropyWithLogits(logits, oneHot);
-        Mean<TFloat32> labelLoss = tf.math.mean(batchLoss.loss(), tf.constant(0));
+        Operand<TFloat32> batchLoss = tf.nn
+                .softmaxCrossEntropyWithLogits(logits, oneHot, -1);
+        Mean<TFloat32> labelLoss = tf.math.mean(batchLoss, tf.constant(0));
         Add<TFloat32> regularizers = tf.math.add(tf.nn.l2Loss(fc1Weights), tf.math
                 .add(tf.nn.l2Loss(fc1Biases),
                         tf.math.add(tf.nn.l2Loss(fc2Weights), tf.nn.l2Loss(fc2Biases))));

--- a/tensorflow-examples/src/main/java/org/tensorflow/model/examples/datasets/ImageBatch.java
+++ b/tensorflow-examples/src/main/java/org/tensorflow/model/examples/datasets/ImageBatch.java
@@ -16,7 +16,7 @@
  */
 package org.tensorflow.model.examples.datasets;
 
-import org.tensorflow.tools.ndarray.ByteNdArray;
+import org.tensorflow.ndarray.ByteNdArray;
 
 /** Batch of images for batch training. */
 public class ImageBatch {

--- a/tensorflow-examples/src/main/java/org/tensorflow/model/examples/datasets/ImageBatchIterator.java
+++ b/tensorflow-examples/src/main/java/org/tensorflow/model/examples/datasets/ImageBatchIterator.java
@@ -16,11 +16,13 @@
  */
 package org.tensorflow.model.examples.datasets;
 
-import static org.tensorflow.tools.ndarray.index.Indices.range;
+import static org.tensorflow.ndarray.index.Indices.range;
 
 import java.util.Iterator;
-import org.tensorflow.tools.ndarray.ByteNdArray;
-import org.tensorflow.tools.ndarray.index.Index;
+
+import org.tensorflow.ndarray.index.Index;
+import org.tensorflow.ndarray.ByteNdArray;
+import org.tensorflow.ndarray.index.Index;
 
 /** Basic batch iterator across images presented in datset. */
 public class ImageBatchIterator implements Iterator<ImageBatch> {

--- a/tensorflow-examples/src/main/java/org/tensorflow/model/examples/datasets/mnist/MnistDataset.java
+++ b/tensorflow-examples/src/main/java/org/tensorflow/model/examples/datasets/mnist/MnistDataset.java
@@ -18,17 +18,17 @@ package org.tensorflow.model.examples.datasets.mnist;
 
 import org.tensorflow.model.examples.datasets.ImageBatch;
 import org.tensorflow.model.examples.datasets.ImageBatchIterator;
-import org.tensorflow.tools.Shape;
-import org.tensorflow.tools.buffer.DataBuffers;
-import org.tensorflow.tools.ndarray.ByteNdArray;
-import org.tensorflow.tools.ndarray.NdArrays;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.ndarray.buffer.DataBuffers;
+import org.tensorflow.ndarray.ByteNdArray;
+import org.tensorflow.ndarray.NdArrays;
 
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.zip.GZIPInputStream;
 
-import static org.tensorflow.tools.ndarray.index.Indices.from;
-import static org.tensorflow.tools.ndarray.index.Indices.to;
+import static org.tensorflow.ndarray.index.Indices.from;
+import static org.tensorflow.ndarray.index.Indices.to;
 
 /** Common loader and data preprocessor for MNIST and FashionMNIST datasets. */
 public class MnistDataset {

--- a/tensorflow-examples/src/main/java/org/tensorflow/model/examples/dense/SimpleMnist.java
+++ b/tensorflow-examples/src/main/java/org/tensorflow/model/examples/dense/SimpleMnist.java
@@ -30,8 +30,8 @@ import org.tensorflow.op.core.Placeholder;
 import org.tensorflow.op.core.Variable;
 import org.tensorflow.op.math.Mean;
 import org.tensorflow.op.nn.Softmax;
-import org.tensorflow.tools.Shape;
-import org.tensorflow.tools.ndarray.ByteNdArray;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.ndarray.ByteNdArray;
 import org.tensorflow.types.TFloat32;
 import org.tensorflow.types.TInt64;
 

--- a/tensorflow-examples/src/main/java/org/tensorflow/model/examples/regression/linear/LinearRegressionExample.java
+++ b/tensorflow-examples/src/main/java/org/tensorflow/model/examples/regression/linear/LinearRegressionExample.java
@@ -29,7 +29,7 @@ import org.tensorflow.op.math.Add;
 import org.tensorflow.op.math.Div;
 import org.tensorflow.op.math.Mul;
 import org.tensorflow.op.math.Pow;
-import org.tensorflow.tools.Shape;
+import org.tensorflow.ndarray.Shape;
 import org.tensorflow.types.TFloat32;
 
 import java.util.List;

--- a/tensorflow-examples/src/main/java/org/tensorflow/model/examples/tensors/TensorCreation.java
+++ b/tensorflow-examples/src/main/java/org/tensorflow/model/examples/tensors/TensorCreation.java
@@ -17,9 +17,9 @@
 package org.tensorflow.model.examples.tensors;
 
 import org.tensorflow.Tensor;
-import org.tensorflow.tools.Shape;
-import org.tensorflow.tools.ndarray.IntNdArray;
-import org.tensorflow.tools.ndarray.NdArrays;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.ndarray.IntNdArray;
+import org.tensorflow.ndarray.NdArrays;
 import org.tensorflow.types.TInt32;
 
 import java.util.Arrays;


### PR DESCRIPTION
It's a draft PR, a few examples works incorrectly.

Operand<TFloat32> batchLoss = tf.nn
                .softmaxCrossEntropyWithLogits(logits, oneHot, -1); - behaviour was changed. 

Now it fails with exception

```
Exception in thread "main" org.tensorflow.exceptions.TFInvalidArgumentException: Dimension must be 2 but is 1 for '{{node SoftmaxCrossEntropyWithLogits/Transpose_1}} = Transpose[T=DT_FLOAT, Tperm=DT_INT64](Add_1, SoftmaxCrossEntropyWithLogits/Concat_1)' with input shapes: [?,10], [1].
	at org.tensorflow.internal.c_api.AbstractTF_Status.throwExceptionIfNotOK(AbstractTF_Status.java:87)
	at org.tensorflow.GraphOperationBuilder.finish(GraphOperationBuilder.java:370)
	at org.tensorflow.GraphOperationBuilder.build(GraphOperationBuilder.java:78)
	at org.tensorflow.GraphOperationBuilder.build(GraphOperationBuilder.java:57)
	at org.tensorflow.op.linalg.Transpose.create(Transpose.java:56)
	at org.tensorflow.op.nn.SoftmaxCrossEntropyWithLogits.moveDimToEnd(SoftmaxCrossEntropyWithLogits.java:211)
	at org.tensorflow.op.nn.SoftmaxCrossEntropyWithLogits.softmaxCrossEntropyWithLogits(SoftmaxCrossEntropyWithLogits.java:104)
	at org.tensorflow.op.NnOps.softmaxCrossEntropyWithLogits(NnOps.java:1873)
	at org.tensorflow.model.examples.cnn.vgg.VGGModel.buildFCLayersAndRegularization(VGGModel.java:163)
	at org.tensorflow.model.examples.cnn.vgg.VGGModel.compile(VGGModel.java:124)
	at org.tensorflow.model.examples.cnn.vgg.VGGModel.<init>(VGGModel.java:76)
	at org.tensorflow.model.examples.cnn.vgg.VGG11OnFashionMNIST.main(VGG11OnFashionMNIST.java:43)
```